### PR TITLE
Cephadm support and other minor changes

### DIFF
--- a/src/check_ceph_df
+++ b/src/check_ceph_df
@@ -22,10 +22,11 @@ import os
 import subprocess
 import sys
 
-__version__ = '1.7.1'
+__version__ = '1.8.0'
 
 # default ceph values
 CEPH_COMMAND = '/usr/bin/ceph'
+CEPH_ADM_COMMAND = '/usr/sbin/cephadm'
 
 # nagios exit code
 STATUS_OK = 0
@@ -38,6 +39,7 @@ def main():
     # parse args
     parser = argparse.ArgumentParser(description="'ceph df' nagios plugin.")
     parser.add_argument('-e','--exe', help='ceph executable [%s]' % CEPH_COMMAND)
+    parser.add_argument('-A','--admexe', help='cephadm executable [%s]' % CEPH_ADM_COMMAND)
     parser.add_argument('-c','--conf', help='alternative ceph conf file')
     parser.add_argument('-m','--monaddress', help='ceph monitor address[:port]')
     parser.add_argument('-i','--id', help='ceph client id')
@@ -48,13 +50,20 @@ def main():
     parser.add_argument('-W','--warn', help="warn above this percent RAW USED", type=float)
     parser.add_argument('-C','--critical', help="critical alert above this percent RAW USED", type=float)
     parser.add_argument('-V','--version', help='show version and exit', action='store_true')
+    parser.add_argument('-a','--cephadm', help='uses cephadm to execute the command', action='store_true')
     args = parser.parse_args()
 
     # validate args
+    cephadm_exec = args.admexe if args.admexe else CEPH_ADM_COMMAND
     ceph_exec = args.exe if args.exe else CEPH_COMMAND
-    if not os.path.exists(ceph_exec):
-        print("ERROR: ceph executable '%s' doesn't exist" % ceph_exec)
-        return STATUS_UNKNOWN
+    if args.cephadm:
+        if not os.path.exists(cephadm_exec):
+            print("ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
+            return STATUS_UNKNOWN
+    else:
+        if not os.path.exists(ceph_exec):
+            print("ERROR: ceph executable '%s' doesn't exist" % ceph_exec)
+            return STATUS_UNKNOWN
 
     if args.version:
         print('version %s' % __version__)
@@ -74,6 +83,17 @@ def main():
 
     # build command
     ceph_df = [ceph_exec]
+
+    if args.cephadm:
+        # Prepend the command with the cephadm binary and the shell command
+        ceph_df = [cephadm_exec, 'shell']
+
+        if args.keyring:
+            ceph_df.append('-v')
+            ceph_df.append('%s:%s:ro' % (args.keyring, args.keyring))
+        ceph_df.append('--')
+        ceph_df.append(ceph_exec)
+
     if args.monaddress:
         ceph_df.append('-m')
         ceph_df.append(args.monaddress)
@@ -216,9 +236,9 @@ def main():
                 return STATUS_OK
 
         #for
-    elif err:
-        # read only first line of error
-        one_line = err.split('\n')[0]
+    elif p.returncode != 0:
+        # read only first line of error, cephadm prints 4 lines
+        one_line = err.split('\n')[4 if args.cephadm else 0]
         if '-1 ' in one_line:
             idx = one_line.rfind('-1 ')
             print('ERROR: %s: %s' % (ceph_exec, one_line[idx+len('-1 '):]))

--- a/src/check_ceph_mgr
+++ b/src/check_ceph_mgr
@@ -23,11 +23,12 @@ import subprocess
 import sys
 import json
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 # default ceph values
 CEPH_EXEC = '/usr/bin/ceph'
 CEPH_COMMAND = 'mgr dump -f json'
+CEPH_ADM_COMMAND = '/usr/sbin/cephadm'
 
 CEPH_MGR_DUMP_EXAMPLE = '''
 $ ceph --version
@@ -102,12 +103,14 @@ def main():
     # parse args
     parser = argparse.ArgumentParser(description="'ceph mgr dump' nagios plugin.")
     parser.add_argument('-e', '--exe', help='ceph executable [%s]' % CEPH_EXEC)
+    parser.add_argument('-A','--admexe', help='cephadm executable [%s]' % CEPH_ADM_COMMAND)
     parser.add_argument('-c', '--conf', help='alternative ceph conf file')
     parser.add_argument('-m', '--monaddress', help='ceph monitor to use for queries (address[:port])')
     parser.add_argument('-i', '--id', help='ceph client id')
     parser.add_argument('-n', '--name', help='ceph client name')
     parser.add_argument('-k', '--keyring', help='ceph client keyring file')
     parser.add_argument('-V', '--version', help='show version and exit', action='store_true')
+    parser.add_argument('-a','--cephadm', help='uses cephadm to execute the command', action='store_true')
     args = parser.parse_args()
 
     if args.version:
@@ -115,10 +118,16 @@ def main():
         return STATUS_OK
 
     # validate args
+    cephadm_exec = args.admexe if args.admexe else CEPH_ADM_COMMAND
     ceph_exec = args.exe if args.exe else CEPH_EXEC
-    if not os.path.exists(ceph_exec):
-        print("MGR ERROR: ceph executable '{}' doesn't exist".format(ceph_exec))
-        return STATUS_UNKNOWN
+    if args.cephadm:
+        if not os.path.exists(cephadm_exec):
+            print("ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
+            return STATUS_UNKNOWN
+    else:
+        if not os.path.exists(ceph_exec):
+            print("MGR ERROR: ceph executable '{}' doesn't exist".format(ceph_exec))
+            return STATUS_UNKNOWN
 
     if args.conf and not os.path.exists(args.conf):
         print("MGR ERROR: ceph conf file '{}' doesn't exist".format(args.conf))
@@ -130,6 +139,16 @@ def main():
 
     # build command
     ceph_cmd = [ceph_exec]
+    if args.cephadm:
+        # Prepend the command with the cephadm binary and the shell command
+        ceph_cmd = [cephadm_exec, 'shell']
+
+        if args.keyring:
+            ceph_cmd.append('-v')
+            ceph_cmd.append('%s:%s:ro' % (args.keyring, args.keyring))
+        ceph_cmd.append('--')
+        ceph_cmd.append(ceph_exec)
+
     if args.monaddress:
         ceph_cmd.append('-m')
         ceph_cmd.append(args.monaddress)

--- a/src/check_ceph_mon
+++ b/src/check_ceph_mon
@@ -26,11 +26,12 @@ import subprocess
 import sys
 import json
 
-__version__ = '1.5.0'
+__version__ = '1.6.0'
 
 # default ceph values
 CEPH_EXEC = '/usr/bin/ceph'
 CEPH_COMMAND = 'quorum_status'
+CEPH_ADM_COMMAND = '/usr/sbin/cephadm'
 
 # nagios exit code
 STATUS_OK = 0
@@ -77,12 +78,14 @@ def main():
   # parse args
   parser = argparse.ArgumentParser(description="'ceph quorum_status' nagios plugin.")
   parser.add_argument('-e','--exe', help='ceph executable [%s]' % CEPH_EXEC)
+  parser.add_argument('-A','--admexe', help='cephadm executable [%s]' % CEPH_ADM_COMMAND)
   parser.add_argument('-c','--conf', help='alternative ceph conf file')
   parser.add_argument('-m','--monaddress', help='ceph monitor to use for queries (address[:port])')
   parser.add_argument('-i','--id', help='ceph client id')
   parser.add_argument('-k','--keyring', help='ceph client keyring file')
   parser.add_argument('-V','--version', help='show version and exit', action='store_true')
   parser.add_argument('-I','--monid', help='mon ID to be checked for availability')
+  parser.add_argument('-a','--cephadm', help='uses cephadm to execute the command', action='store_true')
   args = parser.parse_args()
 
   if args.version:
@@ -90,10 +93,16 @@ def main():
     return STATUS_OK
 
   # validate args
+  cephadm_exec = args.admexe if args.admexe else CEPH_ADM_COMMAND
   ceph_exec = args.exe if args.exe else CEPH_EXEC
-  if not os.path.exists(ceph_exec):
-    print("MON ERROR: ceph executable '%s' doesn't exist" % ceph_exec)
-    return STATUS_UNKNOWN
+  if args.cephadm:
+      if not os.path.exists(cephadm_exec):
+          print("ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
+          return STATUS_UNKNOWN
+  else:
+      if not os.path.exists(ceph_exec):
+          print("ERROR: ceph executable '%s' doesn't exist" % ceph_exec)
+          return STATUS_UNKNOWN
 
   if args.conf and not os.path.exists(args.conf):
     print("MON ERROR: ceph conf file '%s' doesn't exist" % args.conf)
@@ -109,6 +118,18 @@ def main():
 
   # build command
   ceph_cmd = [ceph_exec]
+
+  if args.cephadm:
+    # Prepend the command with the cephadm binary and the shell command
+    ceph_cmd = [cephadm_exec, 'shell'] + ceph_cmd
+    ceph_cmd = [cephadm_exec, 'shell']
+
+    if args.keyring:
+        ceph_cmd.append('-v')
+        ceph_cmd.append('%s:%s:ro' % (args.keyring, args.keyring))
+    ceph_cmd.append('--')
+    ceph_cmd.append(ceph_exec)
+
   if args.monaddress:
     ceph_cmd.append('-m')
     ceph_cmd.append(args.monaddress)

--- a/src/check_ceph_mon
+++ b/src/check_ceph_mon
@@ -96,13 +96,13 @@ def main():
   cephadm_exec = args.admexe if args.admexe else CEPH_ADM_COMMAND
   ceph_exec = args.exe if args.exe else CEPH_EXEC
   if args.cephadm:
-      if not os.path.exists(cephadm_exec):
-          print("ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
-          return STATUS_UNKNOWN
+    if not os.path.exists(cephadm_exec):
+      print("ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
+      return STATUS_UNKNOWN
   else:
-      if not os.path.exists(ceph_exec):
-          print("ERROR: ceph executable '%s' doesn't exist" % ceph_exec)
-          return STATUS_UNKNOWN
+    if not os.path.exists(ceph_exec):
+      print("ERROR: ceph executable '%s' doesn't exist" % ceph_exec)
+      return STATUS_UNKNOWN
 
   if args.conf and not os.path.exists(args.conf):
     print("MON ERROR: ceph conf file '%s' doesn't exist" % args.conf)

--- a/src/check_ceph_mon
+++ b/src/check_ceph_mon
@@ -121,12 +121,11 @@ def main():
 
   if args.cephadm:
     # Prepend the command with the cephadm binary and the shell command
-    ceph_cmd = [cephadm_exec, 'shell'] + ceph_cmd
     ceph_cmd = [cephadm_exec, 'shell']
 
     if args.keyring:
-        ceph_cmd.append('-v')
-        ceph_cmd.append('%s:%s:ro' % (args.keyring, args.keyring))
+      ceph_cmd.append('-v')
+      ceph_cmd.append('%s:%s:ro' % (args.keyring, args.keyring))
     ceph_cmd.append('--')
     ceph_cmd.append(ceph_exec)
 

--- a/src/check_ceph_osd
+++ b/src/check_ceph_osd
@@ -25,9 +25,10 @@ import subprocess
 import sys
 import socket
 
-__version__ = '1.5.2'
+__version__ = '1.6.0'
 
 # default ceph values
+CEPH_ADM_COMMAND = '/usr/sbin/cephadm'
 CEPH_COMMAND = '/usr/bin/ceph'
 
 # nagios exit code
@@ -41,6 +42,7 @@ def main():
   # parse args
   parser = argparse.ArgumentParser(description="'ceph osd' nagios plugin.")
   parser.add_argument('-e','--exe', help='ceph executable [%s]' % CEPH_COMMAND)
+  parser.add_argument('-A','--admexe', help='cephadm executable [%s]' % CEPH_ADM_COMMAND)
   parser.add_argument('-c','--conf', help='alternative ceph conf file')
   parser.add_argument('-m','--monaddress', help='ceph monitor address[:port]')
   parser.add_argument('-i','--id', help='ceph client id')
@@ -50,13 +52,22 @@ def main():
   parser.add_argument('-I','--osdid', help='osd id', required=False)
   parser.add_argument('-C','--crit', help='Number of failed OSDs to trigger critical (default=2)',type=int,default=2, required=False)
   parser.add_argument('-o','--out', help='check osds that are set OUT', default=False, action='store_true', required=False)
+  parser.add_argument('-a','--cephadm', help='uses cephadm to execute the command', action='store_true')
   args = parser.parse_args()
 
   # validate args
+  cephadm_exec = args.admexe if args.admexe else CEPH_ADM_COMMAND
   ceph_exec = args.exe if args.exe else CEPH_COMMAND
-  if not os.path.exists(ceph_exec):
-    print("OSD ERROR: ceph executable '%s' doesn't exist" % ceph_exec)
-    return STATUS_UNKNOWN
+
+  if args.cephadm:
+      if not os.path.exists(cephadm_exec):
+          print("ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
+          return STATUS_UNKNOWN
+  else:
+      if not os.path.exists(ceph_exec):
+          print("ERROR: ceph executable '%s' doesn't exist" % ceph_exec)
+          return STATUS_UNKNOWN
+
 
   if args.version:
     print('version %s' % __version__)
@@ -89,6 +100,18 @@ def main():
 
   # build command
   ceph_cmd = [ceph_exec]
+
+  if args.cephadm:
+    # Prepend the command with the cephadm binary and the shell command
+    ceph_cmd = [cephadm_exec, 'shell'] + ceph_cmd
+    ceph_cmd = [cephadm_exec, 'shell']
+
+    if args.keyring:
+        ceph_cmd.append('-v')
+        ceph_cmd.append('%s:%s:ro' % (args.keyring, args.keyring))
+    ceph_cmd.append('--')
+    ceph_cmd.append(ceph_exec)
+
   if args.monaddress:
       ceph_cmd.append('-m')
       ceph_cmd.append(args.monaddress)

--- a/src/check_ceph_osd
+++ b/src/check_ceph_osd
@@ -107,8 +107,8 @@ def main():
     ceph_cmd = [cephadm_exec, 'shell']
 
     if args.keyring:
-        ceph_cmd.append('-v')
-        ceph_cmd.append('%s:%s:ro' % (args.keyring, args.keyring))
+      ceph_cmd.append('-v')
+      ceph_cmd.append('%s:%s:ro' % (args.keyring, args.keyring))
     ceph_cmd.append('--')
     ceph_cmd.append(ceph_exec)
 

--- a/src/check_ceph_osd
+++ b/src/check_ceph_osd
@@ -60,13 +60,13 @@ def main():
   ceph_exec = args.exe if args.exe else CEPH_COMMAND
 
   if args.cephadm:
-      if not os.path.exists(cephadm_exec):
-          print("ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
-          return STATUS_UNKNOWN
+    if not os.path.exists(cephadm_exec):
+      print("ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
+      return STATUS_UNKNOWN
   else:
-      if not os.path.exists(ceph_exec):
-          print("ERROR: ceph executable '%s' doesn't exist" % ceph_exec)
-          return STATUS_UNKNOWN
+    if not os.path.exists(ceph_exec):
+      print("ERROR: ceph executable '%s' doesn't exist" % ceph_exec)
+      return STATUS_UNKNOWN
 
 
   if args.version:
@@ -103,7 +103,6 @@ def main():
 
   if args.cephadm:
     # Prepend the command with the cephadm binary and the shell command
-    ceph_cmd = [cephadm_exec, 'shell'] + ceph_cmd
     ceph_cmd = [cephadm_exec, 'shell']
 
     if args.keyring:
@@ -113,17 +112,17 @@ def main():
     ceph_cmd.append(ceph_exec)
 
   if args.monaddress:
-      ceph_cmd.append('-m')
-      ceph_cmd.append(args.monaddress)
+    ceph_cmd.append('-m')
+    ceph_cmd.append(args.monaddress)
   if args.conf:
-      ceph_cmd.append('-c')
-      ceph_cmd.append(args.conf)
+    ceph_cmd.append('-c')
+    ceph_cmd.append(args.conf)
   if args.id:
-      ceph_cmd.append('--id')
-      ceph_cmd.append(args.id)
+    ceph_cmd.append('--id')
+    ceph_cmd.append(args.id)
   if args.keyring:
-      ceph_cmd.append('--keyring')
-      ceph_cmd.append(args.keyring)
+    ceph_cmd.append('--keyring')
+    ceph_cmd.append(args.keyring)
   ceph_cmd.append('osd')
   ceph_cmd.append('dump')
 

--- a/src/check_ceph_osd
+++ b/src/check_ceph_osd
@@ -132,7 +132,7 @@ def main():
   output, err = p.communicate()
   output = output.decode('utf8')
 
-  if err or not output:
+  if p.returncode != 0 or not output:
     print("OSD ERROR: %s" % err)
     return STATUS_ERROR
 

--- a/src/check_ceph_osd_db
+++ b/src/check_ceph_osd_db
@@ -164,7 +164,7 @@ def main():
         db_used_bytes = bluefs.get('db_used_bytes')
         perc = (float(db_used_bytes) / float(db_total_bytes) * 100)
 
-        if perc >= args.critical and final_status == STATUS_OK:
+        if perc >= float(args.critical) and final_status == STATUS_OK:
             final_status = STATUS_CRITICAL
 
         lines.append("%s=%.2f%%" % (osd, perc))

--- a/src/check_ceph_osd_db
+++ b/src/check_ceph_osd_db
@@ -128,7 +128,7 @@ def main():
     osd_host = osd_host.replace('[', '\[')
     osd_host = osd_host.replace(']', '\]')
 
-    osds_up = re.findall(r"^(osd\.[^ ]*) up.*%s:" % (osd_host), output, re.MULTILINE)
+    osds_up = re.findall(r"^(osd\.[^ ]*) up.*%s:" % (osd_host), output.decode('utf-8'), re.MULTILINE)
 
     final_status = STATUS_OK
     lines = []
@@ -145,8 +145,8 @@ def main():
         p = subprocess.Popen(daemon_ceph_cmd,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
         output, err = p.communicate()
 
-        if err or not output:
-            print("CRITICAL: %s" % err)
+        if p.returncode != 0 or not output:
+            print("CRITICAL: %s" % '\n'.join(err.decode('utf-8').split('\n')[(4 if args.cephadm else 0):]))
             return STATUS_CRITICAL
 
         try:

--- a/src/check_ceph_osd_db
+++ b/src/check_ceph_osd_db
@@ -24,8 +24,10 @@ import sys
 import socket
 import json
 
+__version__ = '1.1.0'
 
 CEPH_COMMAND = '/usr/bin/ceph'
+CEPH_ADM_COMMAND = '/usr/sbin/cephadm'
 
 STATUS_OK = 0
 STATUS_CRITICAL = 2
@@ -36,19 +38,32 @@ def main():
     parser = argparse.ArgumentParser(description="'ceph osd' nagios plugin.")
 
     parser.add_argument('-e','--exe', help='ceph executable [%s]' % CEPH_COMMAND)
+    parser.add_argument('-A','--admexe', help='cephadm executable [%s]' % CEPH_ADM_COMMAND)
     parser.add_argument('-c','--conf', help='alternative ceph conf file')
     parser.add_argument('-m','--monaddress', help='ceph monitor address[:port]')
     parser.add_argument('-i','--id', help='ceph client id')
     parser.add_argument('-k','--keyring', help='ceph client keyring file')
     parser.add_argument('-H','--host', help='osd host', required=True)
     parser.add_argument('-C','--critical', help='critical threshold', default=60)
+    parser.add_argument('-V','--version', help='show version and exit', action='store_true')
+    parser.add_argument('-a','--cephadm', help='uses cephadm to execute the command', action='store_true')
 
     args = parser.parse_args()
 
+    if args.version:
+        print('version %s' % __version__)
+        return STATUS_OK
+
+    cephadm_exec = args.admexe if args.admexe else CEPH_ADM_COMMAND
     ceph_exec = args.exe if args.exe else CEPH_COMMAND
-    if not os.path.exists(ceph_exec):
-        print("UNKNOWN: ceph executable '%s' doesn't exist" % ceph_exec)
-        return STATUS_UNKNOWN
+    if args.cephadm:
+        if not os.path.exists(cephadm_exec):
+            print("ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
+            return STATUS_UNKNOWN
+    else:
+        if not os.path.exists(ceph_exec):
+            print("UNKNOWN: ceph executable '%s' doesn't exist" % ceph_exec)
+            return STATUS_UNKNOWN
 
     if args.conf and not os.path.exists(args.conf):
         print("UNKNOWN: ceph conf file '%s' doesn't exist" % args.conf)
@@ -71,28 +86,40 @@ def main():
         print('UNKNOWN: could not resolve %s' % args.host)
         return STATUS_UNKNOWN
 
-    ceph_cmd = [ceph_exec]
-    if args.monaddress:
-        ceph_cmd.append('-m')
-        ceph_cmd.append(args.monaddress)
-    if args.conf:
-        ceph_cmd.append('-c')
-        ceph_cmd.append(args.conf)
-    if args.id:
-        ceph_cmd.append('--id')
-        ceph_cmd.append(args.id)
-    if args.keyring:
-        ceph_cmd.append('--keyring')
-        ceph_cmd.append(args.keyring)
+    base_ceph_cmd = [ceph_exec]
 
+    if args.cephadm:
+        # Prepend the command with the cephadm binary and the shell command
+        base_ceph_cmd = [cephadm_exec, 'shell']
+
+        if args.keyring:
+            base_ceph_cmd.append('-v')
+            base_ceph_cmd.append('%s:%s:ro' % (args.keyring, args.keyring))
+        base_ceph_cmd.append('--')
+        base_ceph_cmd.append(ceph_exec)
+
+    if args.monaddress:
+        base_ceph_cmd.append('-m')
+        base_ceph_cmd.append(args.monaddress)
+    if args.conf:
+        base_ceph_cmd.append('-c')
+        base_ceph_cmd.append(args.conf)
+    if args.id:
+        base_ceph_cmd.append('--id')
+        base_ceph_cmd.append(args.id)
+    if args.keyring:
+        base_ceph_cmd.append('--keyring')
+        base_ceph_cmd.append(args.keyring)
+
+    ceph_cmd = base_ceph_cmd.copy()
     ceph_cmd.append('osd')
     ceph_cmd.append('dump')
 
     p = subprocess.Popen(ceph_cmd,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
     output, err = p.communicate()
 
-    if err or not output:
-        print("CRITICAL: %s" % err)
+    if p.returncode != 0 or not output:
+        print("CRITICAL: %s" % '\n'.join(err.decode('utf-8').split('\n')[(4 if args.cephadm else 0):]))
         return STATUS_CRITICAL
 
     # escape IPv4 host address
@@ -107,7 +134,9 @@ def main():
     lines = []
 
     for osd in osds_up:
-        daemon_ceph_cmd = [ceph_exec, '--format', 'json']
+        daemon_ceph_cmd = base_ceph_cmd.copy()
+        daemon_ceph_cmd.append('--format')
+        daemon_ceph_cmd.append('json')
         daemon_ceph_cmd.append('daemon')
         daemon_ceph_cmd.append(osd)
         daemon_ceph_cmd.append('perf')

--- a/src/check_ceph_osd_df
+++ b/src/check_ceph_osd_df
@@ -32,10 +32,11 @@ import json
 from operator import itemgetter
 
 # Semver
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 # default ceph values
 CEPH_COMMAND = '/usr/bin/ceph'
+CEPH_ADM_COMMAND = '/usr/sbin/cephadm'
 
 # nagios exit code
 STATUS_OK = 0
@@ -48,6 +49,7 @@ def main():
     # parse args
     parser = argparse.ArgumentParser(description="'ceph osd df' nagios plugin.")
     parser.add_argument('-e','--exe', help='ceph executable [%s]' % CEPH_COMMAND)
+    parser.add_argument('-A','--admexe', help='cephadm executable [%s]' % CEPH_ADM_COMMAND)
     parser.add_argument('-c','--conf', help='alternative ceph conf file')
     parser.add_argument('-m','--monaddress', help='ceph monitor address[:port]')
     parser.add_argument('-i','--id', help='ceph client id')
@@ -56,13 +58,20 @@ def main():
     parser.add_argument('-W','--warn', help="warn above this percent USED", type=float)
     parser.add_argument('-C','--critical', help="critical alert above this percent USED", type=float)
     parser.add_argument('-V','--version', help='show version and exit', action='store_true')
+    parser.add_argument('-a','--cephadm', help='uses cephadm to execute the command', action='store_true')
     args = parser.parse_args()
 
     # validate args
+    cephadm_exec = args.admexe if args.admexe else CEPH_ADM_COMMAND
     ceph_exec = args.exe if args.exe else CEPH_COMMAND
-    if not os.path.exists(ceph_exec):
-        print("ERROR: ceph executable '%s' doesn't exist" % ceph_exec)
-        return STATUS_UNKNOWN
+    if args.cephadm:
+        if not os.path.exists(cephadm_exec):
+            print("ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
+            return STATUS_UNKNOWN
+    else:
+        if not os.path.exists(ceph_exec):
+            print("ERROR: ceph executable '%s' doesn't exist" % ceph_exec)
+            return STATUS_UNKNOWN
 
     if args.version:
         print('version %s' % __version__)
@@ -82,6 +91,17 @@ def main():
 
     # build command
     ceph_osd_df = [ceph_exec]
+
+    if args.cephadm:
+        # Prepend the command with the cephadm binary and the shell command
+        ceph_osd_df = [cephadm_exec, 'shell']
+
+        if args.keyring:
+            ceph_osd_df.append('-v')
+            ceph_osd_df.append('%s:%s:ro' % (args.keyring, args.keyring))
+        ceph_osd_df.append('--')
+        ceph_osd_df.append(ceph_exec)
+
     if args.monaddress:
         ceph_osd_df.append('-m')
         ceph_osd_df.append(args.monaddress)
@@ -138,9 +158,9 @@ def main():
         except:
             print("ERROR: {}".format(sys.exc_info()[0]))
             return STATUS_UNKNOWN
-    elif err:
-        # read only first line of error
-        one_line = err.split('\n')[0]
+    elif p.returncode != 0:
+        # read only first line of error, cephadm if used prints 4 lines
+        one_line = err.split('\n')[4 if args.cephadm else 0]
         if '-1 ' in one_line:
             idx = one_line.rfind('-1 ')
             print('ERROR: %s: %s' % (ceph_exec, one_line[idx+len('-1 '):]))

--- a/src/check_ceph_rgw
+++ b/src/check_ceph_rgw
@@ -79,14 +79,6 @@ def main():
   if args.cephadm:
     # Prepend the command with the cephadm binary and the shell command
     rgw_cmd = [cephadm_exec, 'shell'] + rgw_cmd
-    rgw_cmd = [cephadm_exec, 'shell']
-
-    if args.keyring:
-      rgw_cmd.append('-v')
-      rgw_cmd.append('%s:%s:ro' % (args.keyring, args.keyring))
-    rgw_cmd.append('--')
-    rgw_cmd.append(rgw_exec)
-
   if args.conf:
     rgw_cmd.append('-c')
     rgw_cmd.append(args.conf)

--- a/src/check_ceph_rgw
+++ b/src/check_ceph_rgw
@@ -25,9 +25,10 @@ import subprocess
 import sys
 import json
 
-__version__ = '1.5.1'
+__version__ = '1.6.0'
 
 # default ceph values
+CEPH_ADM_COMMAND = '/usr/sbin/cephadm'
 RGW_COMMAND = '/usr/bin/radosgw-admin'
 
 # nagios exit code
@@ -43,17 +44,26 @@ def main():
   parser.add_argument('-d','--detail', help='output perf data for all buckets', action='store_true')
   parser.add_argument('-B','--byte', help='output perf data in Byte instead of KB', action='store_true')
   parser.add_argument('-e','--exe', help='radosgw-admin executable [%s]' % RGW_COMMAND)
+  parser.add_argument('-A','--admexe', help='cephadm executable [%s]' % CEPH_ADM_COMMAND)
   parser.add_argument('-c','--conf', help='alternative ceph conf file')
   parser.add_argument('-i','--id', help='ceph client id')
   parser.add_argument('-n','--name', help='ceph client name (type.id)')
   parser.add_argument('-V','--version', help='show version and exit', action='store_true')
+  parser.add_argument('-a','--cephadm', help='uses cephadm to execute the command', action='store_true')
   args = parser.parse_args()
 
   # validate args
+  cephadm_exec = args.admexe if args.admexe else CEPH_ADM_COMMAND
   rgw_exec = args.exe if args.exe else RGW_COMMAND
-  if not os.path.exists(rgw_exec):
-    print("RGW ERROR: radosgw-admin executable '%s' doesn't exist" % rgw_exec)
-    return STATUS_UNKNOWN
+
+  if args.cephadm:
+      if not os.path.exists(cephadm_exec):
+          print("RGW ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
+          return STATUS_UNKNOWN
+      else:
+        if not os.path.exists(rgw_exec):
+          print("RGW ERROR: radosgw-admin executable '%s' doesn't exist" % rgw_exec)
+          return STATUS_UNKNOWN
 
   if args.version:
     print('version %s' % __version__)
@@ -65,7 +75,19 @@ def main():
 
   # build command
   rgw_cmd = [rgw_exec]
-  if args.conf:
+
+  if args.cephadm:
+    # Prepend the command with the cephadm binary and the shell command
+    rgw_cmd = [cephadm_exec, 'shell'] + rgw_cmd
+    rgw_cmd = [cephadm_exec, 'shell']
+
+    if args.keyring:
+      rgw_cmd.append('-v')
+      rgw_cmd.append('%s:%s:ro' % (args.keyring, args.keyring))
+    rgw_cmd.append('--')
+    rgw_cmd.append(rgw_exec)
+
+if args.conf:
     rgw_cmd.append('-c')
     rgw_cmd.append(args.conf)
   if args.id:

--- a/src/check_ceph_rgw
+++ b/src/check_ceph_rgw
@@ -60,10 +60,10 @@ def main():
     if not os.path.exists(cephadm_exec):
       print("RGW ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
       return STATUS_UNKNOWN
-    else:
-      if not os.path.exists(rgw_exec):
-        print("RGW ERROR: radosgw-admin executable '%s' doesn't exist" % rgw_exec)
-        return STATUS_UNKNOWN
+  else:
+    if not os.path.exists(rgw_exec):
+      print("RGW ERROR: radosgw-admin executable '%s' doesn't exist" % rgw_exec)
+      return STATUS_UNKNOWN
 
   if args.version:
     print('version %s' % __version__)

--- a/src/check_ceph_rgw
+++ b/src/check_ceph_rgw
@@ -57,13 +57,13 @@ def main():
   rgw_exec = args.exe if args.exe else RGW_COMMAND
 
   if args.cephadm:
-      if not os.path.exists(cephadm_exec):
-          print("RGW ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
-          return STATUS_UNKNOWN
-      else:
-        if not os.path.exists(rgw_exec):
-          print("RGW ERROR: radosgw-admin executable '%s' doesn't exist" % rgw_exec)
-          return STATUS_UNKNOWN
+    if not os.path.exists(cephadm_exec):
+      print("RGW ERROR: cephadm executable '%s' doesn't exist" % cephadm_exec)
+      return STATUS_UNKNOWN
+    else:
+      if not os.path.exists(rgw_exec):
+        print("RGW ERROR: radosgw-admin executable '%s' doesn't exist" % rgw_exec)
+        return STATUS_UNKNOWN
 
   if args.version:
     print('version %s' % __version__)
@@ -87,7 +87,7 @@ def main():
     rgw_cmd.append('--')
     rgw_cmd.append(rgw_exec)
 
-if args.conf:
+  if args.conf:
     rgw_cmd.append('-c')
     rgw_cmd.append(args.conf)
   if args.id:


### PR DESCRIPTION
This PR adds cephadm support for:
- check_ceph_df
- check_ceph_mgr
- check_ceph_mon
- check_ceph_osd
- check_ceph_osd_df
- check_ceph_rgw
- check_ceph_osd_db

It is implemented following # 68 so thanks go to WarriorXK for the original PR.

While at it I added support using other than the default keyring with cephadm which fixes # 87.

To make it work on my Python 3 I also needed to make changes similar to # 84 in order to avoid errors when handling output from `ceph`.

Indentation was fixed in `check_ceph_osd`. Some files continue to use 4 spaces and others use 2...

Added version to `check_ceph_osd_db` and also the second call to `ceph` inside the loop will now use ID/keyring/etc. arguments in the same way as the initial call to `ceph`. Also, if critical limit is given with `-C` argument it needs to be cast to a float (at least on my Python 3.9).

The PR works for me but I have not done extensive testing. Especially I might have missed some error handling/UTF-8 decoding in output processing.  
I am sure there could be room to improve so feedback is very welcome.